### PR TITLE
null out timer once it fires

### DIFF
--- a/ext/data/content-script.js
+++ b/ext/data/content-script.js
@@ -12,6 +12,7 @@ function sendToChrome(type, requests, callback, timeout) {
   var callbackID = nextCallbackID++;
   var timer = setTimeout(function() {
     callback({errorCode: 5});
+    timer = null;
   }, 1000 * (timeout || DEFAULT_TIMEOUT_SECONDS));
 
   self.port.on(type + "Response", function onResponse(id, response) {


### PR DESCRIPTION
Oops, I forgot to amend my last commit to include this. This prevents the callback from firing a second time after a timeout.
