### PR TITLE
Allow u2f object to be extended and added in private window

### DIFF
--- a/ext/data/content-script.js
+++ b/ext/data/content-script.js
@@ -53,12 +53,6 @@ function cloneFunctions(obj, clone) {
       cloneFunctions(obj[i], clone[i]);
   }
 }
-/* eslint-disable no-unused-vars */
-function cloneFullyInto(obj, scope) {
-  var clone = cloneInto(obj, scope);
-  cloneFunctions(obj, clone);
-}
-/* eslint-enable no-unused-vars */
 
 var u2f = {
   register: function(requests, signRequests, callback, timeout) {

--- a/ext/data/content-script.js
+++ b/ext/data/content-script.js
@@ -6,6 +6,8 @@ const DEFAULT_TIMEOUT_SECONDS = 30;
 
 var nextCallbackID = 0;
 
+var noopOnPage = exportFunction(() => {}, unsafeWindow);
+
 function sendToChrome(msg, callback, timeout) {
   var origin = document.location.origin;
   var callbackID = nextCallbackID++;
@@ -42,16 +44,21 @@ function sendToChrome(msg, callback, timeout) {
 }
 
 function cloneFunctions(obj, clone) {
-  for (var i in obj) {
-    if (!obj.hasOwnProperty(i))
-      continue;
-    else if (typeof obj[i] == "function")
-      exportFunction(obj[i], clone, {
-        defineAs: i
+  Object.getOwnPropertyNames(obj).forEach(i => {
+    if (typeof obj[i] == "function") {
+      // instead of freezing the clone use accessor property to allow further extension
+      let value = exportFunction(obj[i], clone);
+      let getter = exportFunction(() => {
+        return value;
+      }, clone);
+      Object.defineProperty(clone, i, {
+        get: getter,
+        set: noopOnPage // readonly: silently avoid strict mode TypeError on assignment
       });
-    else if (typeof obj[i] == "object")
+    } else if (typeof obj[i] == "object") {
       cloneFunctions(obj[i], clone[i]);
-  }
+    }
+  });
 }
 
 var u2f = {
@@ -98,5 +105,3 @@ var u2fOnPage = createObjectIn(unsafeWindow, {
   defineAs: "u2f"
 });
 cloneFunctions(u2f, u2fOnPage);
-
-Object.freeze(u2fOnPage);

--- a/ext/package.json
+++ b/ext/package.json
@@ -10,6 +10,9 @@
     "Baptiste Mille-Mathias",
     "Matt N"
   ],
+  "permissions": {
+    "private-browsing": true
+  },
   "engines": {
     "firefox": ">=38.0a1"
   },


### PR DESCRIPTION
Allowing extensions (not freezing) the u2f object more gracefully allows services that integrate with the google provided reference javascript code. Duo is a u2f service provider that relies on the ability to add properties to the u2f object.
