### PR TITLE
Revert "Make this works after changes to detection code on github"

### DIFF
--- a/ext/data/content-script.js
+++ b/ext/data/content-script.js
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-/* globals cloneInto, exportFunction, unsafeWindow */
+/* globals cloneInto, createObjectIn, exportFunction, unsafeWindow */
 "use strict";
 
 const DEFAULT_TIMEOUT_SECONDS = 30;
@@ -112,7 +112,7 @@ var u2f = {
   }
 };
 
-exportFunction(function(){}, unsafeWindow, {
+var u2fOnPage = createObjectIn(unsafeWindow, {
   defineAs: "u2f"
 });
-cloneFunctions(u2f, unsafeWindow.u2f);
+cloneFunctions(u2f, u2fOnPage);


### PR DESCRIPTION
I believe whatever detection code was on github has been fixed and the referenced commit is no longer needed. Moreover, it breaks the detection used by RP Duo Security, as they use `typeof u2f == "object"`.

This reverts commit 33c361bbe5833ad2938a265edc7a86e462880c50.
