### PR TITLE
Remove hyphen from phrasal verb

### DIFF
--- a/ext/index.js
+++ b/ext/index.js
@@ -126,7 +126,7 @@ function _execBin(event, origin, challenges, checkSignChallenges, callbackid, wo
     response.value += data;
     if (response.value[0] == "i") {
       log("insert device");
-      showNotification(_("Please plug-in your U2F device"));
+      showNotification(_("Please plug in your U2F device"));
       response.value = response.value.substr(1);
     }
     if (response.value[0] == "j") {


### PR DESCRIPTION
In the phrase "Please plug-in ...", "plug-in" is a phrasal verb: a verb + a preposition.
It is incorrect to hyphenate phrasal verbs.

Sources:
- https://en.oxforddictionaries.com/punctuation/hyphen
  "You should NOT put a hyphen within phrasal verbs - verbs made up of a main verb and an adverb or preposition."
- http://www.quickanddirtytips.com/education/grammar/phrasal-verbs
  "there are no hyphens in phrasal verbs when you use them as verbs"